### PR TITLE
Add new zephyr workflows and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ compile_commands.json
 .cache
 **/build/*
 build/*
-build*
 generated
 
 # Python stuff

--- a/workflow-templates/zephyr/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/workflow-templates/zephyr/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report about something not working
+title: BUG - <subject title related to the issue>
+labels: "type: bug"
+assignees: ""
+---
+
+**Describe the bug**
+
+<!-- A clear and concise description of what the bug is. -->
+
+**Firmware/Software Version**
+
+**Hardware Version**
+
+**To Reproduce**
+
+<!-- Steps to reproduce the behavior: -->
+
+<!-- 1. Go to '...' -->
+<!-- 2. Click on '....' -->
+
+**Additional context**
+
+<!-- Add any other context about the problem here. -->

--- a/workflow-templates/zephyr/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/workflow-templates/zephyr/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Development issue describing something new to be added to the project
+title: "<subject title related to the issue>"
+labels: "type: feature request"
+assignees: ""
+---
+
+## Context
+
+<!--- Provide some context why is this feature needed.
+Does it build from an existing feature, does it enable an implementation of some other new feature? -->
+
+## Required steps / Implementation details
+
+<!--- Either provide a list of steps that are required for this feature and/or provide technical details on how this feature will be implemented. -->
+
+## Definition of Done
+
+<!--- Explicitly define conditions when this feature request is considered done, so it can be reviewed and validated. -->
+
+<!-- For example: Described feature is implemented, documented, tested and reviewed. -->

--- a/workflow-templates/zephyr/.github/pr-labeler.yml
+++ b/workflow-templates/zephyr/.github/pr-labeler.yml
@@ -1,0 +1,4 @@
+# Add lables (on the left) to the PRs of specific branches (on the right)
+pull request: feature/*
+release: release/*
+fix: fix/*

--- a/workflow-templates/zephyr/.github/pull_request_template.md
+++ b/workflow-templates/zephyr/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Description
+
+<!--- A summary of the changes that this PR introduces. Provide a relevant motivation and context about this PR or link an issue that provides it. -->
+
+Closes #
+
+Related #
+
+## Areas of interest for the reviewer
+
+<!--- Which parts of the code should the code reviewer check?  -->
+
+## Checklist
+
+<!--- Check items that you fulfilled, strikeout the ones that do not apply and write why  -->
+
+- [ ] My code follows the [style guidelines] as defined by BA-RD-AIS.
+- [ ] I have performed a self-review of my code.
+- [ ] My changes generate no new warnings.
+- [ ] I added/updated source code documentation for all newly added or changed
+      functions.
+- [ ] I updated all customer-facing technical documentation.
+
+Example strikeout: - [x] ~~I updated all customer-facing technical documentation.~~ - This PR introduced only internal facing changes.
+
+## After-review steps
+
+<!--- Delete section or select one option -->
+
+- Reviewer can merge and delete the branch.
+- I will merge PR by myself.
+
+[style guidelines]:
+  https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md

--- a/workflow-templates/zephyr/.github/workflows/build.yaml
+++ b/workflow-templates/zephyr/.github/workflows/build.yaml
@@ -1,0 +1,87 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      checkout_ref:
+        required: true
+        type: string
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+        # Set work dir to "project" for all 'run' calls. Beware, everything else
+        # (actions, 'with' params, etc.) still needs to reference full path.
+        working-directory: project
+
+    steps:
+      - name: Checkout last PR commit
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: project
+
+      - name: Checkout last tag
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.checkout_ref }}
+          path: project
+
+      - name: Retrieve cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-modules
+        with:
+          path: |
+            bootloader
+            modules
+            nrf
+            nrfxlib
+            test
+            tools
+            zephyr
+            ~/.local/share/east/downloads/
+            ~/.local/share/east/nrfutil-toolchain-manager.exe
+          # Note above two lines, if we are caching entire ~/.local/share/east
+          # folder then cache action fails during download/extract step
+          key:
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{
+            hashFiles('project/west.yml') }}
+          restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+          cache: "pip"
+          cache-dependency-path: project/scripts/requirements.txt
+
+      - name: Install dependencies
+        run: make install-dep
+
+      - name: Setup project
+        run: make project-setup
+
+      - name: Pre-build
+        run: make pre-build
+
+      - name: Build
+        run: make build
+
+      - name: Pre-package
+        if: github.event_name == 'workflow_dispatch'
+        run: make post-build
+
+      - name: Package artefacts
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v3
+        with:
+          name: artefacts
+          path: project/artefacts/*

--- a/workflow-templates/zephyr/.github/workflows/create-release.yaml
+++ b/workflow-templates/zephyr/.github/workflows/create-release.yaml
@@ -1,0 +1,89 @@
+name: "Create Release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description:
+          "The version you want to release [v##.##.##]? (BTW, did you update
+          changelog?)"
+        required: true
+env:
+  GIT_TERMINAL_PROMPT: 0
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Fetch history for all branches and tags
+
+      - name: Validate version input
+        id: validate-input
+        run: |
+          # Check if input version is in correct format
+          if [[ ! ${{ inputs.version }} =~ v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid input version: wrong format!"
+            exit 1
+          fi
+          # Check if input version already exists as git tag
+          if [[ ! -z $(git tag | grep ${{ inputs.version }}) ]]; then
+            echo "::error::Invalid input version: it already exists!"
+            exit 1
+          fi
+
+      - name: Update Changelog
+        uses: IRNAS/keep-a-changelog-new-release@v1.3.1
+        with:
+          tag: ${{ inputs.version }}
+
+      # In order to make a commit, we need to initialize a user.
+      - name: Create Robot user
+        run: |
+          git config user.name "github-bot :robot:"
+          git config user.email noreply@github.com
+
+      - name: Commit Changelog, create tag and push
+        run: |
+          git add CHANGELOG.md
+          git commit -m "Update CHANGELOG.md for Release ${{ inputs.version }}"
+          git tag ${{ inputs.version }}
+          git push
+          git push origin ${{ inputs.version }}
+
+  call-build:
+    needs: update-changelog
+    uses: ./.github/workflows/build.yaml
+    with:
+      checkout_ref: ${{ inputs.version }}
+
+  call-publish-release:
+    needs: call-build
+    uses: ./.github/workflows/publish-release.yaml
+    with:
+      release_version: ${{ inputs.version }}
+
+  cleanup-on-failure:
+    # Only run cleanup if either call-build or call-publish-release fail.
+    needs: [call-build, call-publish-release]
+    if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.version }}
+          # Fetch two commits, so you can hard reset below
+          fetch-depth: 2
+
+      - name: Cleanup tag and Changelog
+        run: |
+          git config user.name "github-bot :robot:"
+          git config user.email noreply@github.com
+          git reset --hard HEAD~1
+          git push --force origin HEAD:main
+          git tag -d ${{ inputs.version }}
+          git push --delete origin  ${{ inputs.version }}

--- a/workflow-templates/zephyr/.github/workflows/label_pr.yml
+++ b/workflow-templates/zephyr/.github/workflows/label_pr.yml
@@ -1,0 +1,18 @@
+name: Label PR
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: TimonVS/pr-labeler-action@v4.1.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/zephyr/.github/workflows/publish-release.yaml
+++ b/workflow-templates/zephyr/.github/workflows/publish-release.yaml
@@ -1,0 +1,67 @@
+name: "Publish Release"
+
+on:
+  workflow_call:
+    inputs:
+      release_version:
+        required: true
+        type: string
+
+jobs:
+  publish-new-release:
+    runs-on: ubuntu-22.04
+    # runs-on: self-hosted
+
+    steps:
+      - name: Start
+        run: |
+          version_cut=$(echo "${{ inputs.release_version }}" | cut -c 2-)
+          echo "release_version=${{ inputs.release_version }}" >> $GITHUB_ENV
+          echo "release_version_cut=$version_cut" >> $GITHUB_ENV
+
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.release_version }}
+
+      - name: Get latest Changelog entry
+        id: changelog-reader
+        uses: mindsers/changelog-reader-action@v2.2.2
+        with:
+          version: ${{ env.release_version_cut }}
+
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: artefacts
+          path: artefacts
+
+      - name: Read extra release notes
+        run: |
+          # Echoing contents of the below .md files needs to be done in special
+          # manner, as they will usually be multiline strings.
+          # EOF needs to be random value for security reasons
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "pre_changelog<<$EOF" >> $GITHUB_ENV
+          echo "$(cat artefacts/pre_changelog.md)" >> $GITHUB_ENV
+          echo "$EOF" >> $GITHUB_ENV
+          echo "post_changelog<<$EOF" >> $GITHUB_ENV
+          echo "$(cat artefacts/post_changelog.md)" >> $GITHUB_ENV
+          echo "$EOF" >> $GITHUB_ENV
+          rm -f artefacts/pre_changelog.md
+          rm -f artefacts/post_changelog.md
+
+      - name: Publish Release
+        if: ${{ !env.ACT }}
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          files: artefacts/*
+          tag_name: ${{ env.release_version }}
+          body: |
+            # Release notes
+
+            ${{ env.pre_changelog }}
+
+            ${{ steps.changelog-reader.outputs.changes }}
+
+            ${{ env.post_changelog }}

--- a/workflow-templates/zephyr/README.md
+++ b/workflow-templates/zephyr/README.md
@@ -1,0 +1,180 @@
+# Zephyr
+
+## Description
+
+Workflows in this group extend the workflows in [Basic](../basic/README.md)
+group and introduce several new functionalities which aid in the development of
+the projects using Zephyr.
+
+Specifically, they provide:
+
+- Everything that [Basic](../basic/README.md) workflows already do: changelog
+  preparation, tagging, publishing GitHub releases, etc.,
+- Running _builds_ on Pull Requests and during releases processes,
+- Caching of West modules and toolchains downloaded by East to speed up the
+  _build_ process,
+- A way to change what _build_ means for each project,
+- A way to specify which artefacts are attached to the published GitHub releases
+  for each project,
+- A tag and Changelog cleanup steps when _build_ goes wrong and
+- A way to add custom text to the release notes.
+
+## Dependencies
+
+Workflows in this group expect specific files to be present in the repository to
+function properly. If you created your repository from `irnas-zephyr-template`
+then you are all set with basic defaults.
+
+Needed files (relative to project's root dir):
+
+- `scripts/requirements.txt`, can be empty,
+- `makefile` - Specific content is expected, see section
+  [How to configure _build_](#how-to-configure-build).
+
+### How to use
+
+This group contains four workflows:
+
+- `create-release.yaml`
+- `publish-release.yaml`
+- `build.yaml`
+- `label_pr.yaml`
+
+They can be used in two different scenarios:
+
+- During a release process
+- In Pull Requests
+
+#### Release process
+
+To trigger a release process just follow the instructions in the Basic's
+[How to use](../basic/README.md#how-to-use) section.
+
+Everything that is described in that section still applies, with some
+modifications:
+
+- After creating a release tag and a new changelog section a `build.yaml`
+  workflow is called.
+- `build.yaml` runs a _build_ process.
+- After that `publish-release.yaml` takes any resulting _build_ artefacts and
+  creates a GitHub release with them.
+
+If anything goes wrong during `build.yaml` and `publish-release.yaml` workflows
+then the created release tag and Changelog update commit are deleted from the
+`main` branch.
+
+#### Pull requests
+
+`build.yaml` (and therefore _build_ process) is automatically triggered whenever
+a PR is opened, reopened or a new commit is pushed to the PR.
+
+## How to configure _build_
+
+Besides a bit of Zephyr-specific environment setup and caching, the `build.yaml`
+is very generic and makes no assumptions about what a Zephyr project needs to do
+to build artefacts and create releases. The generic approach comes from using
+Make and the `makefile` file present in the project's root directory.
+
+After running the equivalent of the below commands:
+
+```bash
+# Clone the repo into the `project` folder
+# mkdir -p <project_name>/project
+# cd <project_name>/project
+# git clone <project_url> .
+
+# Check the cache for West modules and East toolchain and extract if found
+# Check the cache for Python dependencies based on scripts/requirements.txt
+```
+
+the `build.yaml` starts to execute `make` commands in the following order:
+
+```bash
+make install-dep
+make project-setup
+make pre-build
+make build
+make pre-package    # Used in the release process, skipped during PRs
+```
+
+It is up to the developer to decide what these commands do. A good starting
+point is the
+[makefile](https://github.com/IRNAS/irnas-zephyr-template/blob/main/makefile)
+that is provided by `irnas-zephyr-template` repo by default.
+
+Note: all `make` commands are executed from the root of the cloned repository.
+Even if some command would `cd` into some other folder, the next command would
+still execute from the root.
+
+Expected behaviour of each `make` command:
+
+- `make install-dep` - Installs tooling needed by the project.
+- `make project-setup` - Sets up the project and any tooling that might depend
+  on it.
+- `make pre-build` - Runs commands that need to run before the _build_.
+- `make build` - The _build_, the heart of the workflow. This could be a single
+  build command or a set of build commands.
+- `make pre-package` - Only used in the release process, it is skipped if the
+  workflow was triggered due to a PR. Use it to package build artefacts.
+
+### Packaging build artefacts
+
+In release processes, the `build.yaml` will collect any files found in the
+`artefacts` folder of the project's root directory and attach them to the newly
+created a GitHub release as release artefacts.
+
+The developer can use the `make pre-package` command to create the `artefacts`
+folder and move any files of interest inside it.
+
+Packaging of build artefacts is done only in release processes, it is skipped if
+the workflow was triggered due to a PR.
+
+### Adding extra text to the Release notes
+
+Some projects need additional information in the Release Notes apart from the
+changelog notes, maybe general usage instructions, an explanation of the build
+artefacts or some dynamically generated report.
+
+To do that the `make pre-package` command can copy into the `artefacts` folder
+the `pre_changelog.md` and `post_changelog.md` markdown files.
+
+Contents of these files then becomes a part of the Release Notes in the
+following way:
+
+```markdown
+# Release notes
+
+{Contents of the pre_changelog.md}
+
+{Contents of the changelog for this version}
+
+{Contents of the post_changelog.md}
+```
+
+If a section is not used, the corresponding file can be empty.
+`pre_changelog.md` and `post_changelog.md` files are not attached to the created
+release, even though they are present in the `artefacts` folder.
+
+### A short note about Make
+
+Make is a build automation tool, often used for managing source code
+dependencies and executing compiler commands.
+
+It can do many things, but our use of it is very simple. If we create a
+`makefile` file with the below content:
+
+```makefile
+pre-build:
+    echo "Running pre-build target"
+
+build:
+    echo "Running build target"
+```
+
+And then run `make pre-build` or `make build`, we would be greeted with one of
+the above messages. We essentially aliased `make pre-build` and `make build`
+commands to do something arbitrary.
+
+To learn more about Make read the excellent
+[Memfault's Interrupt blog](https://interrupt.memfault.com/blog/gnu-make-guidelines)
+about it.


### PR DESCRIPTION
## Description

<!--- A summary of the changes that this PR introduces. Provide a relevant motivation and context about this PR or link an issue that provides it. -->
This PR adds need Zephyr workflow files that can:
* Run the build during release process and capture the build artefacts,
* Run the build whenever a PR is opened, reopened or synchronised. 

The working example is already live in the https://github.com/IRNAS/irnas-zephyr-template repo.
The migration script from the previous PR can also migrate to this setup.


## Areas of interest for the reviewer

<!--- Which parts of the code should the code reviewer check?  -->
Check the added README, see if it is clearly written, if it can be reduced, etc.
Tell me if you are missing anything, I tried to think a bit more broadly 
regarding what can be automated, maybe I have missed some low hanging fruit.
Also check the `makefile` in the template repo, the main build logic is demonstrated there.

## After-review steps

<!--- Delete section or select one option -->

- I will merge PR by myself.

[style guidelines]:
  https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
